### PR TITLE
Fixed issue with logic to import Lodestone Id

### DIFF
--- a/FFXIVAPP.Client/FFXIVAPP.Client.csproj
+++ b/FFXIVAPP.Client/FFXIVAPP.Client.csproj
@@ -47,23 +47,20 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FFXIVAPP.Common, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\FFXIVAPP.Common.4.0.4\lib\NET461\FFXIVAPP.Common.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FFXIVAPP.Common.4.0.4\lib\net461\FFXIVAPP.Common.dll</HintPath>
     </Reference>
     <Reference Include="FFXIVAPP.IPluginInterface, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\FFXIVAPP.IPluginInterface.4.0.3\lib\NET461\FFXIVAPP.IPluginInterface.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FFXIVAPP.IPluginInterface.4.0.4\lib\net461\FFXIVAPP.IPluginInterface.dll</HintPath>
     </Reference>
     <Reference Include="FFXIVAPP.ResourceFiles, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\FFXIVAPP.ResourceFiles.1.0.3\lib\NET461\FFXIVAPP.ResourceFiles.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FFXIVAPP.ResourceFiles.1.0.3\lib\net461\FFXIVAPP.ResourceFiles.dll</HintPath>
+    </Reference>
+    <Reference Include="HtmlAgilityPack, Version=1.4.9.5, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\packages\HtmlAgilityPack.1.4.9.5\lib\Net45\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="Machina, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Machina.1.0.3\lib\NET461\Machina.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.4.9.5, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\packages\HtmlAgilityPack.1.4.9.5\lib\Net45\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="MahApps.Metro, Version=1.5.0.23, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.1.5.0\lib\net45\MahApps.Metro.dll</HintPath>
@@ -92,6 +89,7 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.1.5.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
@@ -267,7 +265,9 @@
     <None Include="app.manifest">
       <SubType>Designer</SubType>
     </None>
-    <None Include="NLog.config" />
+    <Content Include="NLog.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="NLog.xsd">
       <SubType>Designer</SubType>
     </None>

--- a/FFXIVAPP.Client/ViewModels/SettingsViewModel.cs
+++ b/FFXIVAPP.Client/ViewModels/SettingsViewModel.cs
@@ -241,7 +241,7 @@ namespace FFXIVAPP.Client.ViewModels
                         doc.Load(stream);
                         try
                         {
-                            // A tag which has two child elements, one with the character name and one with the world name (case sensitive)
+                            // a tag which has two child elements, one with the character name and one with the world name (case sensitive)
                             var xpathMatch = doc.DocumentNode
                                 .SelectSingleNode($"//a[@href and descendant::*[text() = '{characterName}'] and descendant::*[text() = '{serverName}']]");
 

--- a/FFXIVAPP.Client/ViewModels/SettingsViewModel.cs
+++ b/FFXIVAPP.Client/ViewModels/SettingsViewModel.cs
@@ -241,12 +241,18 @@ namespace FFXIVAPP.Client.ViewModels
                         doc.Load(stream);
                         try
                         {
-                            var htmlSource = doc.DocumentNode.SelectSingleNode("//html")
-                                                .OuterHtml;
-                            var CICUID = new Regex(@"(?<cicuid>\d+)/string.Empty>" + HttpUtility.HtmlEncode(characterName), RegexOptions.ExplicitCapture | RegexOptions.Multiline | RegexOptions.IgnoreCase);
-                            cicuid = CICUID.Match(htmlSource)
-                                           .Groups["cicuid"]
-                                           .Value;
+                            // A tag which has two child elements, one with the character name and one with the world name (case sensitive)
+                            var xpathMatch = doc.DocumentNode
+                                .SelectSingleNode($"//a[@href and descendant::*[text() = '{characterName}'] and descendant::*[text() = '{serverName}']]");
+
+                            if (xpathMatch != null)
+                            {
+                                var profileUrl = xpathMatch.GetAttributeValue("href", "");
+                                var regexMatch = Regex.Match(profileUrl, @"/(?<uid>\d+)/");
+
+                                if (regexMatch.Success)
+                                    cicuid = regexMatch.Groups["uid"].Value;
+                            }
                         }
                         catch (Exception ex)
                         {

--- a/FFXIVAPP.Updater/FFXIVAPP.Updater.csproj
+++ b/FFXIVAPP.Updater/FFXIVAPP.Updater.csproj
@@ -96,6 +96,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.1.5.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
- Updated HTML scraping logic for retrieving uid from lodestone character search
- Fixed build issue due to invalid package version in csproj

Checking the code, it seems like this _CICUID_ property isn't used anywhere in the client. Is there a specific purpose for it?